### PR TITLE
Added parsing for address bitfields, added trace commenting capability

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -4,4 +4,12 @@
 #define ADDRWIDTH 8
 #define FILELOC 1
 
+//Defines for Parsing shifts and masks
+#define BYTESELECTWIDTH 6
+#define BYTESELECTMASK	0x3F
+#define INDEXWIDTH	14
+#define INDEXMASK	0x3FFF
+#define TAGWIDTH	12
+#define TAGMASK		0xFFF
+
 #endif // _DEFINES_H_

--- a/include/trace.h
+++ b/include/trace.h
@@ -8,6 +8,9 @@
 typedef struct Traces{
 	uint8_t n;
 	uint32_t address;
+	uint8_t byte;
+	uint16_t index;
+	uint16_t tag;
 } Trace;
 
 Trace ParseTrace(char* buffer);

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
 #include "defines.h"
 #include "trace.h"
 
-#define FILEBUFFS 12
+#define FILEBUFFS 60
 
 uint8_t traceMode = 0;
 

--- a/src/trace.c
+++ b/src/trace.c
@@ -9,12 +9,18 @@ Trace ParseTrace(char* buffer) {
 
 	Trace event = {};
 
+	// Parse command and address
         event.n = buffer[0] - '0';
 	strncpy(tempAddress, &buffer[2], ADDRWIDTH);
 	event.address = strtoul(tempAddress, NULL, 16);	
 	
+	// Parse address into tag, index, and byte
+	event.byte = event.address & BYTESELECTMASK;
+	event.index = (event.address >> BYTESELECTWIDTH) & INDEXMASK;
+	event.tag = (event.address >> (BYTESELECTWIDTH + INDEXWIDTH)) & TAGMASK;
+	
 #ifdef DEBUG
-	printf("CMD = %d\taddress = %08x\n", event.n, event.address);
+	printf("CMD = %d\taddress = %08x\t tag = %03x index = %04x byte = %02x\n", event.n, event.address, event.tag, event.index, event.byte);
 #endif	
 
 	return event;

--- a/testing/vwidth.din
+++ b/testing/vwidth.din
@@ -1,0 +1,16 @@
+0 0BADBAD0 // Given rwin test with known results
+0 1BADBAD2
+1 2BADBAD0
+6 0BADBAD0
+6 1BADBAD1
+6 2BADBAD0
+9 BAD0BAD0
+2 408ed4   // Some traces with shorter width
+0 10019d94
+2 408ed8
+1 10019d88
+2 408edc
+0 10013220
+2 408ee0
+2 408ee4
+1 100230b8


### PR DESCRIPTION
Verified that parser correctly handles shorter trace addresses.

Added tag, index, and byte members to the Trace struct.
Added mask and bitwidth definitions for tag, index, and byte.
Added parsing for tag, index, and byte.
Added printing of tag, index, and byte when debug enabled.

Increased file buffer to allow for commented trace files.

Added "vwidth.din" trace file that includes some shorter traces and comments.